### PR TITLE
1406: Support FIDC deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The framework comes with a set of tests that test the SAPI-G core (Plain FAPI) d
 Default configuration that is shipped with the framework can be found here: [src/main/resources/config.json](src/main/resources/config.json)
 
 The config file supports placeholders, allowing config to be customised using environment variables.
-Placeholders are of the form: `{{ENV_VAR_NAME}}`.
+Placeholders are of the form: `${VAR}` , or to supply a default value: `${VAR:-defaultValue}`
 
 If an environment variable cannot be found, then the framework will fail to load the config file with an exception.
 
@@ -18,7 +18,13 @@ If an environment variable cannot be found, then the framework will fail to load
 | API_UNDER_TEST_SERVER_TLD | The TLD of the environment to run the tests against                                      | dev-core.forgerock.financial |
 | API_PROVIDER_ORG_ID       | The organisation id that the ApiClient belongs to as registered in the Trusted Directory | 0015800001041REAAY           |
 | API_PROVIDER_SOFTWARE_ID  | The softwate_id of the ApiClient's software statement in the Trusted Directory           | Y6NjA9TOn3aMm9GaPtLwkp       |
+| AM_REALM                  | The realm in AM being used for the OAuth2 provider for this deployment                   | alpha                        |
+| AM_COOKIE_NAME            | The name of the AM cookie that needs to be set when doing end user authentication        | iPlanetDirectoryPro          |
 
+### Config implementation details
+3rd Party library used: https://github.com/sksamuel/hoplite
+
+Variables in config can be replaced using different methods, further details: https://github.com/sksamuel/hoplite?tab=readme-ov-file#built-in-preprocessors
 
 ## Set up the certificates for test purposes
 The certificates are protected, and you can't find them in the repository, for that reason to run the functional tests in local environments is necessary set the OB certificates:

--- a/src/main/kotlin/com/forgerock/sapi/gateway/framework/configuration/ConfigurationManager.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/framework/configuration/ConfigurationManager.kt
@@ -77,7 +77,7 @@ class ConfigurationManager(private val filePath: String = EXTERNAL_SYSTEM_DEPEND
         }
 
         fun getApiClients(): List<ApiClient> {
-            var apiClients: MutableList<ApiClient> = mutableListOf()
+            val apiClients: MutableList<ApiClient> = mutableListOf()
             apiUnderTest.devTrustedDirectory.apiClients.forEach { (_, devApiClient) ->
                 apiClients.add(devApiClient)
             }
@@ -91,8 +91,6 @@ class ConfigurationManager(private val filePath: String = EXTERNAL_SYSTEM_DEPEND
     override fun beforeAll(context: ExtensionContext?) {
         Security.addProvider(BouncyCastleProvider())
         val config = loadConfig()
-        val variables = getVariableValues(config.variables)
-        doVariableSubstitution(config, variables)
 
         println("Creating TPP using ${config.trustedDirectory.name}")
         for (apiClientConfig in config.trustedDirectory.apiClients) {
@@ -106,18 +104,5 @@ class ConfigurationManager(private val filePath: String = EXTERNAL_SYSTEM_DEPEND
             )
         }
         apiUnderTest = ApiUnderTest(config.apiUnderTest)
-    }
-
-    private fun getVariableValues(variables: List<String>): Map<String, String> {
-        val variableVals: MutableMap<String, String> = mutableMapOf()
-        for (variable in variables) {
-            val envVar = System.getenv(variable)
-            if (envVar == null) {
-                throw Exception("Variable $variable defined in config file does not have an environment variable $variable set")
-            } else {
-                variableVals[variable] = envVar
-            }
-        }
-        return variableVals
     }
 }

--- a/src/main/kotlin/com/forgerock/sapi/gateway/framework/configuration/ExternalSystemDependenciesConfig.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/framework/configuration/ExternalSystemDependenciesConfig.kt
@@ -4,64 +4,6 @@ package com.forgerock.sapi.gateway.framework.configuration
  * This class is initialized by Jackson from the config file specified in Config.kt
  */
 data class ExternalSystemDependenciesConfig(
-    val variables: List<String>,
     val trustedDirectory: ProductionTrustedDirectoryConfig,
     val apiUnderTest: ApiConfig
 )
-
-fun doVariableSubstitution(systemDependenciesConfig: ExternalSystemDependenciesConfig, variables: Map<String, String>){
-    systemDependenciesConfig.trustedDirectory.name =
-        substituteVariables(systemDependenciesConfig.trustedDirectory.name, variables)
-    systemDependenciesConfig.trustedDirectory.jwks_uri =
-        substituteVariables(systemDependenciesConfig.trustedDirectory.jwks_uri, variables)
-    systemDependenciesConfig.trustedDirectory.openidWellKnown =
-        substituteVariables(systemDependenciesConfig.trustedDirectory.openidWellKnown, variables)
-    systemDependenciesConfig.trustedDirectory.ssaUrl =
-        substituteVariables(systemDependenciesConfig.trustedDirectory.ssaUrl, variables)
-    systemDependenciesConfig.trustedDirectory.scopesToAccessSsa =
-        substituteVariables(systemDependenciesConfig.trustedDirectory.scopesToAccessSsa, variables)
-
-    systemDependenciesConfig.trustedDirectory.apiClients.forEach {
-        it.orgId = substituteVariables(it.orgId, variables)
-        it.softwareId = substituteVariables(it.softwareId, variables)
-        it.publicSigningKeyID = substituteVariables(it.publicSigningKeyID, variables)
-        it.publicSigningPemPath = substituteVariables(it.publicSigningPemPath, variables)
-        it.privateSigningPemPath = substituteVariables(it.privateSigningPemPath, variables)
-        it.privateTransportPemPath = substituteVariables(it.privateTransportPemPath, variables)
-        it.publicTransportKeyID = substituteVariables(it.publicTransportKeyID, variables)
-        it.publicTransportPemPath = substituteVariables(it.publicTransportPemPath, variables)
-    }
-
-    systemDependenciesConfig.apiUnderTest.name =
-        substituteVariables(systemDependenciesConfig.apiUnderTest.name, variables)
-    systemDependenciesConfig.apiUnderTest.serverDomain =
-        substituteVariables(systemDependenciesConfig.apiUnderTest.serverDomain, variables)
-    systemDependenciesConfig.apiUnderTest.oidcWellKnownUrl =
-        substituteVariables(systemDependenciesConfig.apiUnderTest.oidcWellKnownUrl, variables)
-    systemDependenciesConfig.apiUnderTest.rsDiscoveryUrl =
-        substituteVariables(systemDependenciesConfig.apiUnderTest.rsDiscoveryUrl, variables)
-
-    systemDependenciesConfig.apiUnderTest.devTrustedDirectory.oidcWellKnownUrl =
-        substituteVariables(systemDependenciesConfig.apiUnderTest.devTrustedDirectory.oidcWellKnownUrl, variables)
-
-    systemDependenciesConfig.apiUnderTest.devTrustedDirectory.getKeysUrl =
-        substituteVariables(systemDependenciesConfig.apiUnderTest.devTrustedDirectory.getKeysUrl, variables)
-    systemDependenciesConfig.apiUnderTest.devTrustedDirectory.getTransportPemsUrl =
-        substituteVariables(systemDependenciesConfig.apiUnderTest.devTrustedDirectory.getTransportPemsUrl, variables)
-    systemDependenciesConfig.apiUnderTest.devTrustedDirectory.getSigningPemsUrl =
-        substituteVariables(systemDependenciesConfig.apiUnderTest.devTrustedDirectory.getSigningPemsUrl, variables)
-    systemDependenciesConfig.apiUnderTest.devTrustedDirectory.getSsaUrl =
-        substituteVariables(systemDependenciesConfig.apiUnderTest.devTrustedDirectory.getSsaUrl, variables)
-}
-
-fun substituteVariables(templateValue: String, variables: Map<String, String>): String{
-    var substitutedString = templateValue
-    for(variable in variables){
-        substitutedString = substituteVariable(substitutedString, "{{${variable.key}}}", variable.value)
-    }
-    return substitutedString
-}
-
-fun substituteVariable(templateValue: String, variableName: String, variableValue: String): String{
-    return templateValue.replace(variableName, variableValue)
-}

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -1,19 +1,14 @@
 {
-  "variables": [
-    "API_UNDER_TEST_SERVER_TLD",
-    "API_PROVIDER_ORG_ID",
-    "API_PROVIDER_SOFTWARE_ID"
-  ],
   "trustedDirectory": {
     "name": "Open Banking Test Directory",
     "jwks_uri": "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks",
     "openid_well_known": "https://matls-sso.openbankingtest.org.uk/.well-known/openid-configuration",
-    "ssa_url": "https://matls-dirapi.openbankingtest.org.uk/organisation/tpp/{{API_PROVIDER_ORG_ID}}/software-statement/{{API_PROVIDER_SOFTWARE_ID}}/software-statement-assertion",
+    "ssa_url": "https://matls-dirapi.openbankingtest.org.uk/organisation/tpp/${API_PROVIDER_ORG_ID}/software-statement/${API_PROVIDER_SOFTWARE_ID}/software-statement-assertion",
     "scopesToAccessSsa": "ASPSPReadAccess TPPReadAccess AuthoritiesReadAccess",
     "api_clients": [
       {
-        "org_id": "{{API_PROVIDER_ORG_ID}}",
-        "software_id": "{{API_PROVIDER_SOFTWARE_ID}}",
+        "org_id": "${API_PROVIDER_ORG_ID}",
+        "software_id": "${API_PROVIDER_SOFTWARE_ID}",
         "publicTransportKeyID": "52TVNALuXKCYzvxgBALeDVp966I",
         "publicTransportPemPath": "./certificates/OBWac.pem",
         "privateTransportPemPath": "./certificates/OBWac.key",
@@ -28,31 +23,31 @@
     }
   },
   "apiUnderTest": {
-    "name": "{{API_UNDER_TEST_SERVER_TLD}}",
-    "serverDomain": "{{API_UNDER_TEST_SERVER_TLD}}",
+    "name": "${API_UNDER_TEST_SERVER_TLD}",
+    "serverDomain": "${API_UNDER_TEST_SERVER_TLD}",
     "fapiSecurityProfile": "FAPI_1_0_ADVANCED",
     "consentHandlerTyep": "AmSimpleConsent",
-    "cookieName": "iPlanetDirectoryPro",
-    "oidcWellKnownUrl": "https://sapig.{{API_UNDER_TEST_SERVER_TLD}}/am/oauth2/realms/root/realms/alpha/.well-known/openid-configuration",
-    "rsDiscoveryUrl": "https://mtls.sapig.{{API_UNDER_TEST_SERVER_TLD}}/rs/open-banking/discovery",
+    "cookieName": "${AM_COOKIE_NAME:-iPlanetDirectoryPro}",
+    "oidcWellKnownUrl": "https://sapig.${API_UNDER_TEST_SERVER_TLD}/am/oauth2/realms/root/realms/${AM_REALM:-alpha}/.well-known/openid-configuration",
+    "rsDiscoveryUrl": "https://mtls.sapig.${API_UNDER_TEST_SERVER_TLD}/rs/open-banking/discovery",
     "resourceOwners": [
       {
         "username": "psu4test",
         "password": "0penBanking!"
       }
     ],
-    "authenticatePath": "/am/json/realms/root/realms/alpha/authenticate",
+    "authenticatePath": "/am/json/realms/root/realms/${AM_REALM:-alpha}/authenticate",
     "devTrustedDirectory": {
       "api_clients": [],
       "name": "IG Untrusted Directory",
-      "getKeysUrl": "https://sapig.{{API_UNDER_TEST_SERVER_TLD}}/jwkms/apiclient/issuecert",
-      "getTransportPemsUrl": "https://sapig.{{API_UNDER_TEST_SERVER_TLD}}/jwkms/apiclient/gettlscert",
-      "getSigningPemsUrl": "https://sapig.{{API_UNDER_TEST_SERVER_TLD}}/jwkms/apiclient/getsigcert",
-      "getSsaUrl": "https://sapig.{{API_UNDER_TEST_SERVER_TLD}}/jwkms/apiclient/getssa",
+      "getKeysUrl": "https://sapig.${API_UNDER_TEST_SERVER_TLD}/jwkms/apiclient/issuecert",
+      "getTransportPemsUrl": "https://sapig.${API_UNDER_TEST_SERVER_TLD}/jwkms/apiclient/gettlscert",
+      "getSigningPemsUrl": "https://sapig.${API_UNDER_TEST_SERVER_TLD}/jwkms/apiclient/getsigcert",
+      "getSsaUrl": "https://sapig.${API_UNDER_TEST_SERVER_TLD}/jwkms/apiclient/getssa",
       "ssa_claim_names": {
         "redirect_uris": "software_redirect_uris"
       },
-      "oidcWellKnownUrl": "https://sapig.{{API_UNDER_TEST_SERVER_TLD}}/am/oauth2/realms/root/realms/alpha/.well-known/openid-configuration",
+      "oidcWellKnownUrl": "https://sapig.${API_UNDER_TEST_SERVER_TLD}/am/oauth2/realms/root/realms/${AM_REALM:-alpha}/.well-known/openid-configuration",
       "roles": [
         "DATA",
         "AISP",


### PR DESCRIPTION
- Add AM_REALM and AM_COOKIE_NAME config variables to allow tests to be run against FIDC
- Use the config library's builtin functional for var placeholder replacement with env var values

https://github.com/SecureApiGateway/SecureApiGateway/issues/1406