### PR TITLE
1428: Use Test Trusted Directory SSAs with jwks_uri values

### DIFF
--- a/src/main/kotlin/com/forgerock/sapi/gateway/framework/api/ApiUnderTest.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/framework/api/ApiUnderTest.kt
@@ -5,7 +5,6 @@ import com.forgerock.sapi.gateway.framework.fapi.FapiSecurityProfile
 import com.forgerock.sapi.gateway.framework.oauth.OAuth2Server
 import com.forgerock.sapi.gateway.framework.oidc.OidcWellKnown
 import com.forgerock.sapi.gateway.framework.trusteddirectory.DevelopmentTrustedDirectory
-import com.forgerock.sapi.gateway.framework.trusteddirectory.certificateproviders.ApiCertificateProvider
 import com.forgerock.sapi.gateway.framework.configuration.ResourceOwner
 
 /**
@@ -20,10 +19,7 @@ class ApiUnderTest(val apiConfig: ApiConfig) {
         // created lazily to break the cyclic dependency (DevelopmentTrustedDirectory depends on ApiUnderTest)
         val devDirectoryConfig = apiConfig.devTrustedDirectory
         println("Creating DevelopmentTrustedDirectory $devDirectoryConfig.name")
-        DevelopmentTrustedDirectory(
-            devDirectoryConfig,
-            ApiCertificateProvider(devDirectoryConfig)
-        )
+        DevelopmentTrustedDirectory(devDirectoryConfig)
     }
     val authenticatePath: String = apiConfig.authenticatePath
     val resourceOwners: MutableList<ResourceOwner> = mutableListOf()

--- a/src/main/kotlin/com/forgerock/sapi/gateway/framework/platform/register/SoftwareStatementRequest.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/framework/platform/register/SoftwareStatementRequest.kt
@@ -13,5 +13,5 @@ data class SoftwareStatementRequest(
     val software_policy_uri: String = "https://tpp.com/policy.html",
     val software_logo_uri: String = "https://tpp.com/tpp.png",
     val software_roles: List<String> = listOf("DATA", "AISP", "PISP", "CBPII"),
-    val software_jwks: Map<String, Any>
+    val software_jwks: Map<String, Any>? = null
 )

--- a/src/main/kotlin/com/forgerock/sapi/gateway/framework/trusteddirectory/certificateproviders/ApiCertificateProvider.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/framework/trusteddirectory/certificateproviders/ApiCertificateProvider.kt
@@ -12,7 +12,10 @@ import com.github.kittinunf.fuel.core.isSuccessful
 import com.nimbusds.jose.jwk.JWKSet
 import javax.net.ssl.SSLSocketFactory
 
-class ApiCertificateProvider(val devDirectoryConfig: DevelopmentTrustedDirectoryConfig) :
+class ApiCertificateProvider(private val devDirectoryConfig: DevelopmentTrustedDirectoryConfig,
+                             orgId: String,
+                             orgName: String,
+                             softwareId: String) :
     CertificateProvider {
 
     val jwkSet: Map<String, Any>
@@ -25,7 +28,7 @@ class ApiCertificateProvider(val devDirectoryConfig: DevelopmentTrustedDirectory
     init {
         val getKeysUrl = devDirectoryConfig.getKeysUrl
         val (_, response, result) = Fuel.post(getKeysUrl)
-            .jsonBody("{\"org_id\": \"PSDGB-FFA-5f563e89742b2800145c7da1\",\"org_name\": \"Acme Fintech\"}")
+            .jsonBody(mapOf("org_id" to orgId, "org_name" to orgName, "software_id" to softwareId))
             .header(Headers.CONTENT_TYPE, "application/json")
             .responseObject<Map<String, Any>>()
 


### PR DESCRIPTION
Instructing the Test Trusted Directory to issue an SSA with a jwks_uri, instead of embedding the JWKS. This is achieved by omitting the software_jwks from the SSA request.

Updating the ApiCertificateProvider to provide the software_id, so that we are able to use the jwks_uri.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1428