### PR TITLE
1556: Update to be compatible with error produced by code migrated to PingGateway openig-fapi module

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/core/FapiDynamicClientRegistrationTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/core/FapiDynamicClientRegistrationTest.kt
@@ -159,7 +159,7 @@ class FapiDynamicClientRegistrationTest {
             // Override the JWT signer to use a kid not in the client's JWKS
             registerApiClient.registrationRequestJwtSigner = { validKeyPair, signingAlgorithm, jwtClaimsSet ->
                 registerApiClient.signedRegistrationRequestJwt(
-                    KeyPairHolder(validKeyPair.privateKey, validKeyPair.publicCert, "unknown-kid", validKeyPair.type),
+                    KeyPairHolder(generateRsaPrivateKey(), validKeyPair.publicCert, "unknown-kid", validKeyPair.type),
                     signingAlgorithm,
                     jwtClaimsSet
                 )
@@ -197,8 +197,9 @@ class FapiDynamicClientRegistrationTest {
             assertThat(response.statusCode).isEqualTo(400)
             assertThat(errorResponse.error).isEqualTo("invalid_client_metadata")
             assertThat(errorResponse.errorDescription).isEqualTo(
-                "Registration Request signature is invalid: 'jwk for kid: ${clientConfig.transportKeys.keyID} must be signing key, instead found: tls'")
+                "Registration Request JWT is invalid: Expected JWT to have a valid signature")
         }
+
 
         private fun generateRsaPrivateKey(): PrivateKey {
             try {
@@ -280,7 +281,7 @@ class FapiDynamicClientRegistrationTest {
                     builder.expirationTime(Date(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5)))
                 },
                 "invalid_client_metadata",
-                "registration request jwt has expired"
+                "Registration Request JWT is invalid: Expected timestamp 'exp' to be after the given datetime"
             )
         }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/core/FapiDynamicClientRegistrationTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/core/FapiDynamicClientRegistrationTest.kt
@@ -358,7 +358,7 @@ class FapiDynamicClientRegistrationTest {
             assertThat(response.statusCode).isEqualTo(400)
             assertThat(errorResponse.error).isEqualTo("invalid_software_statement")
             assertThat(errorResponse.errorDescription).isEqualTo(
-                "Failed to validate SSA against jwks_uri 'https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks'")
+                "Registration Request contains an invalid software_statement, Expected JWT to have a valid signature")
         }
 
         @Test
@@ -389,7 +389,8 @@ class FapiDynamicClientRegistrationTest {
             assertThat(response.statusCode).isEqualTo(400)
             assertThat(errorResponse.error).isEqualTo("unapproved_software_statement")
             assertThat(errorResponse.errorDescription).isEqualTo(
-                "The issuer of the software statement is unrecognised")
+                "Registration Request contains an unapproved software_statement, " +
+                        "issuer 'Unknown Trusted Directory' is not supported")
         }
 
     }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/core/FapiDynamicClientRegistrationTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/core/FapiDynamicClientRegistrationTest.kt
@@ -121,7 +121,8 @@ class FapiDynamicClientRegistrationTest {
 
             assertThat(response.statusCode).isEqualTo(400)
             assertThat(errorResponse.error).isEqualTo("invalid_client_metadata")
-            assertThat(errorResponse.errorDescription).isEqualTo("Registration Request signature is invalid: 'jwt signed using unsupported algorithm: RS256'")
+            assertThat(errorResponse.errorDescription).isEqualTo("Registration Request JWT is invalid: " +
+                    "Expected JWT to be signed using one of the supported 'alg' values: [ES256, PS256]")
         }
 
         @Test
@@ -150,7 +151,7 @@ class FapiDynamicClientRegistrationTest {
 
             assertThat(response.statusCode).isEqualTo(400)
             assertThat(errorResponse.error).isEqualTo("invalid_client_metadata")
-            assertThat(errorResponse.errorDescription).isEqualTo("Registration Request signature is invalid: 'jwt signature verification failed'")
+            assertThat(errorResponse.errorDescription).isEqualTo("Registration Request JWT is invalid: Expected JWT to have a valid signature")
         }
 
         @Test
@@ -173,7 +174,7 @@ class FapiDynamicClientRegistrationTest {
 
             assertThat(response.statusCode).isEqualTo(400)
             assertThat(errorResponse.error).isEqualTo("invalid_client_metadata")
-            assertThat(errorResponse.errorDescription).isEqualTo("Registration Request signature is invalid: 'jwk not found in supplied jwkSet for kid: unknown-kid'")
+            assertThat(errorResponse.errorDescription).isEqualTo("Registration Request JWT is invalid: Expected JWT to have a valid signature")
         }
 
         @Test


### PR DESCRIPTION
Updating functional tests to be compatible with the code migrated to PingGateway openig-fapi module.

These tests need to be run against a core deployment of this PR: https://github.com/SecureApiGateway/secure-api-gateway-core/pull/80 (until the PR is merged to main).

https://github.com/SecureApiGateway/SecureApiGateway/issues/1556