### PR TITLE
OPENIG-8594 Fix broken test where only PS256 alg supported

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/core/FapiDynamicClientRegistrationTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/core/FapiDynamicClientRegistrationTest.kt
@@ -122,7 +122,7 @@ class FapiDynamicClientRegistrationTest {
             assertThat(response.statusCode).isEqualTo(400)
             assertThat(errorResponse.error).isEqualTo("invalid_client_metadata")
             assertThat(errorResponse.errorDescription).isEqualTo("Registration Request JWT is invalid: " +
-                    "Expected JWT to be signed using one of the supported 'alg' values: [ES256, PS256]")
+                    "Expected JWT to be signed using one of the supported 'alg' values: [PS256]")
         }
 
         @Test


### PR DESCRIPTION
OPENIG-8594 Fix broken test as the tests are configured with only `[PS256]` supporting algorithm (restricted), as demonstrated on the IG pod - `var/ig/config/routes/routes-service/20-as-dcr-endpoint.json`:
```json
        {
          "comment": "Pull the registration request from the entity and create a RegistrationRequest object context attribute",
          "name": "RegistrationRequestBuilderFilter",
          "type": "RegistrationRequestBuilderFilter",
          "config": {
            "trustedDirectoryService": "TrustedDirectoryService",
            "jwkSetService": "JwkSetService",
            "supportedSigningAlgorithms": ["PS256"]
          }
        },
        {
          "comment": "Validate that the request will result in an OAuth2 client that is FAPI compliant",
          "name": "FapiAdvancedDCRValidationFilter",
          "type": "FapiAdvancedDCRValidationFilter",
          "config": {
            "certificateRetriever": "ContextCertificateRetriever",
            "supportedSigningAlgorithms": ["PS256"],
            "supportedTokenEndpointAuthMethods": "${oauth2.tokenEndpointAuthMethodsSupported}"
          }
        },
```