### PR TITLE
1681: Amend Test Framework repo

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/core/FapiDynamicClientRegistrationTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/core/FapiDynamicClientRegistrationTest.kt
@@ -79,7 +79,7 @@ class FapiDynamicClientRegistrationTest {
             )
 
             assertThat(response.statusCode).isEqualTo(400)
-            assertThat(errorResponse.errorDescription).isEqualTo("Client mTLS certificate not provided")
+            assertThat(errorResponse.errorDescription).isEqualTo("Client TLS certificate is missing or malformed")
         }
 
         @Test


### PR DESCRIPTION
Update returned error when TLS certificate is missing

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1681