### PR TITLE
1707: Fix Tests to work with 2025.6.0 of OpenIG

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/core/PlainFapiApiEndpointTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/core/PlainFapiApiEndpointTest.kt
@@ -106,7 +106,7 @@ class PlainFapiApiEndpointTest : MultipleApiClientTest() {
         errorResponse.errorDescription?.let {
             errorDescription = it
         }
-        assertThat(errorDescription).contains("Token grant type must be in: ", ignoreCase = true)
+        assertThat(errorDescription).contains("Token grant type must be: ", ignoreCase = true)
         assertThat(errorDescription).contains("authorization_code", ignoreCase = false)
         assertThat(errorDescription).contains("refresh_token", ignoreCase = false)
     }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/core/PlainFapiApiEndpointTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/core/PlainFapiApiEndpointTest.kt
@@ -106,9 +106,7 @@ class PlainFapiApiEndpointTest : MultipleApiClientTest() {
         errorResponse.errorDescription?.let {
             errorDescription = it
         }
-        assertThat(errorDescription).contains("Token grant type must be: ", ignoreCase = true)
-        assertThat(errorDescription).contains("authorization_code", ignoreCase = false)
-        assertThat(errorDescription).contains("refresh_token", ignoreCase = false)
+        assertThat(errorDescription).isEqualTo("Token grant type must be: authorization_code")
     }
 
     @Test


### PR DESCRIPTION
Remove 'in' to align test with expected output

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1707